### PR TITLE
Harden containers

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,4 @@
+RAILS_ENV=development
 MYSQL_ROOT_PASSWORD=mysqlrootpw
 MYSQL_DATABASE=gamberodb
 MYSQL_USER=gambero

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ WORKDIR /gambero
 RUN apk add --update \
   bash \
   build-base \
+  curl \
   libxml2-dev \
   libxslt-dev \
   postgresql-dev \
@@ -11,9 +12,11 @@ RUN apk add --update \
   nodejs \
   tzdata \
   && rm -rf /var/cache/apk/*
+# Drop root as soon as possible
+RUN addgroup -S gambero && adduser -S gambero -G gambero
+USER gambero
 CMD /gambero/docker-entrypoint.sh
-
-# COPY commands come last, so that the rebuild takes as few steps as possible
+HEALTHCHECK --timeout=5s CMD curl -f http://localhost:3000
 
 # The gemfile is rarely updated, so this COPY will allow to cache the expensive `bundle install`
 COPY ./Gemfile ./Gemfile.lock /gambero/

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN apk add --update \
 RUN addgroup -S gambero && adduser -S gambero -G gambero
 USER gambero
 CMD /gambero/docker-entrypoint.sh
-HEALTHCHECK --timeout=5s CMD curl -f http://localhost:3000
+HEALTHCHECK --timeout=5s CMD curl -f http://localhost:8080
 
 # The gemfile is rarely updated, so this COPY will allow to cache the expensive `bundle install`
 COPY ./Gemfile ./Gemfile.lock /gambero/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.4'
 services:
   app:
     image: gambero:latest
@@ -8,21 +8,42 @@ services:
       - RAILS_ENV # One of "development", "test", "production"
     volumes:
       - .:/gambero
+    security_opt:
+      - no-new-privileges
+    read_only: true
     networks:
       default:
         ipv4_address: 172.20.0.2
+    healthcheck:
+      interval: 5m
+      retries: 3
+      start_period: 30s
   db:
     image: mariadb
     volumes:
       - ./mariadb:/var/lib/mysql
+    # tmpfs's must be explicitly declared, because / is by default read-only (read_only: true).
+    tmpfs:
+      - /tmp
+      - /run/mysqld
+      - /var/run
     environment:
       - MYSQL_ROOT_PASSWORD
       - MYSQL_DATABASE
       - MYSQL_USER
       - MYSQL_PASSWORD
+    security_opt:
+      - no-new-privileges
     networks:
       default:
         ipv4_address: 172.20.0.3
+    read_only: true
+    healthcheck:
+      test: ["CMD-SHELL", "mysqladmin ping -u $MYSQL_USER -p$MYSQL_PASSWORD -h 172.20.0.3 || exit 1"]
+      interval: 5m
+      timeout: 5s
+      retries: 3
+      start_period: 30s
 
 networks:
   default:

--- a/docs/host-hardening.md
+++ b/docs/host-hardening.md
@@ -1,0 +1,8 @@
+# Hardening the Docker host
+
+In order to satisfy the Docker Security Benchmark, the following measures must be applied at a minimum (starting from a default, non-swarm install of Docker). **Do not forget** to run [docker-bench-security](https://github.com/docker/docker-bench-security) to catch any additional issues.
+
+ * Set the environment variable `DOCKER_CONTENT_TRUST=1` (eg. in .profile or .bashrc)
+ * `chmod a+rwx -R logs/ tmp/` (the app container won't work without this!)
+ * `chmod a+rw db/schema.rb` (likewise)
+ * Make sure that dockerd is launched with the following flags (eg. inspect `service status docker.service` if using systemd): `--icc=false --live-restore --userns-remap=default --userland-proxy=false --no-new-privileges`


### PR DESCRIPTION
Harden Docker image and docker-compose config with the help of [docker-bench-security](https://github.com/docker/docker-bench-security).

Note that this is not sufficient for a hardened system in production, as the Docker host must also be hardened.