### PR TITLE
Enable Sphinx search server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN apk add --update \
   sqlite-dev \
   nodejs \
   tzdata \
+  sphinx \
   && rm -rf /var/cache/apk/*
 CMD /gambero/docker-entrypoint.sh
 

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -21,7 +21,7 @@ class SearchController < ApplicationController
       if @search.valid?
         begin
           @search.search_for_user!(@user)
-        rescue ThinkingSph::ConnectionError
+        rescue ThinkingSphinx::ConnectionError
           flash[:error] = I18n.t 'controllers.search_controller.flasherrorsearchcontroller'
         end
       end

--- a/config/thinking_shinx.yml
+++ b/config/thinking_shinx.yml
@@ -1,7 +1,0 @@
-production:
-  address: 127.0.0.1
-  port: 9313
-  min_infix_len: 2
-
-development:
-  min_infix_len: 2

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -17,6 +17,10 @@ else
   bundle exec rake db:migrate
 fi
 
+# Run ThinkingSphinx rake tasks to configure Sphinx
+bundle exec rake ts:index
+bundle exec rake ts:start
+
 # Set out SECRET_KEY_BASE
 if [ "$SECRET_KEY_BASE" = "" ]; then
   echo "No SECRET_KEY_BASE provided, generating one now."


### PR DESCRIPTION
Installa Sphinx nel container `app` e lo configura utilizzando la gem ThinkingSphinx.

Per facilità non ho tirato su un container dedicato a Sphinx. Se invece pensate sia meglio avere un container dedicato ditemelo. Secondo me, essendo una funzionalità collaterale, è meglio preferire la semplicità (ho dovuto aggiungere solo 3 righe).