### PR TITLE
Enable reverse proxy caching

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -5,10 +5,10 @@ server {
     listen [::]:80;
     server_name gambe.ro;
 
-    location / {
-        return 301 https://$host$request_uri;
-    }
+    return 301 https://gambe.ro$request_uri;
 }
+
+proxy_cache_path /tmp/nginx-cache levels=1:2 keys_zone=gamberocache:10m inactive=24h max_size=100m use_temp_path=off;
 
 server {
     listen 443 ssl http2;
@@ -20,6 +20,18 @@ server {
 
     # Enable HSTS for 1 year
     add_header Strict-Transport-Security "max-age=31536000" always;
+
+    location /assets {
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Host $http_host;
+        proxy_pass http://gambe.ro.local:8080/assets;
+        # Check that the cache is working
+        # add_header X-Cache-Status $upstream_cache_status;
+        proxy_cache gamberocache;
+        proxy_cache_valid 1d;
+    }
 
     location / {
         proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
Abilita il reverse proxy caching per gli asset: cose come il logo, la favicon, etc. vengono servite direttamente dalla cache di Nginx anzichè essere richieste all'applicazione.