### PR TITLE
Template fixes

### DIFF
--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -95,19 +95,25 @@ var _Lobsters = Class.extend({
       d.append(a);
     });
 
-    $(voterEl).after(d);
-
-    d.position({
-      my: "left top",
-      at: "left bottom",
-      offset: "-2 -2",
-      of: $(voterEl),
-      collision: "none",
-    });
-
-    /* XXX: why is this needed? */
-    if (thingType == "story")
+    if (thingType == "story") {
+      $(voterEl).closest("li").after(d);
+      d.position({
+        my: "left top",
+        at: "left bottom",
+        offset: "-2 -2",
+        of: $(voterEl),
+        collision: "none",
+      });
       d.css("left", $(voterEl).position().left);
+    } else {
+      // place downvote menu outside of the comment to avoid inheriting opacity
+      var voterPos = $(voterEl).position();
+      d.appendTo($(voterEl).closest("li"));
+      d.css({
+        left: voterPos.left,
+        top: voterPos.top + $(voterEl).outerHeight()
+      });
+    }
   },
 
   vote: function(thingType, voterEl, point, reason) {

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -793,6 +793,7 @@ a.pagelink.curpage {
 	display: block;
 	padding: 3px;
 	font-size: 9pt;
+	text-decoration: none;
 }
 #downvote_why a:hover {
 	background-color: #eee;

--- a/app/assets/stylesheets/mobile.css
+++ b/app/assets/stylesheets/mobile.css
@@ -107,15 +107,16 @@
 		padding-bottom: 0.75em;
 		width: 100%;
 	}
-	ol.stories.list li.story div.mobile_comments {
+	ol.stories.list li.story .mobile_comments {
 		background-color: #e8e8e8;
 		display: table-cell !important;
 		font-size: 11pt;
 		min-width: 40px;
 		text-align: center;
+		text-decoration: none;
 		vertical-align: middle;
 	}
-	ol.stories.list li.story div.mobile_comments a:before {
+	ol.stories.list li.story .mobile_comments span:before {
 		border-style: solid;
 		border-width: 0px 6px 3px 0px;
 		border-color: #ccc;
@@ -129,7 +130,7 @@
 		width: 5px;
 		z-index: 10;
 	}
-	ol.stories.list li.story div.mobile_comments a:after {
+	ol.stories.list li.story .mobile_comments span:after {
 		border-bottom-right-radius: 10px;
 		border-color: #ccc;
 		border-style: solid;
@@ -143,7 +144,7 @@
 		width: 10px;
 		z-index: 10;
 	}
-	ol.stories.list li.story div.mobile_comments a {
+	ol.stories.list li.story .mobile_comments span {
 		background-color: #ccc;
 		border: 1px solid #ccc;
 		border-radius: 5px;
@@ -156,20 +157,20 @@
 		text-align: center;
 		text-decoration: none;
 	}
-	ol.stories.list li.story div.mobile_comments a:active,
-	ol.stories.list li.story div.mobile_comments a:focus {
+	ol.stories.list li.story .mobile_comments:active span,
+	ol.stories.list li.story .mobile_comments:focus span {
 		outline: 0;
 	}
-	ol.stories.list li.story div.mobile_comments.zero a {
+	ol.stories.list li.story .mobile_comments.zero span {
 		color: gray;
 	}
-	ol.stories.list li.story div.mobile_comments.zero a {
+	ol.stories.list li.story .mobile_comments.zero span {
 		background-color: #d8d8d8;
 		color: #999;
 	}
-	ol.stories.list li.story div.mobile_comments.zero a,
-	ol.stories.list li.story div.mobile_comments.zero a:before,
-	ol.stories.list li.story div.mobile_comments.zero a:after {
+	ol.stories.list li.story .mobile_comments.zero span,
+	ol.stories.list li.story .mobile_comments.zero span:before,
+	ol.stories.list li.story .mobile_comments.zero span:after {
 		border-color: #d8d8d8;
 	}
 	ol.stories.list li.story span.comments_label {

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -112,7 +112,7 @@ class MessagesController < ApplicationController
       end
     end
 
-    flash[:success] = I18n.t 'controllers.messages_controller.flashdelmsg',  :nbmsg => "#{deleted}", :plural => "#{deleted == 1 ? "" : "s"}"
+    flash[:success] = I18n.t 'controllers.messages_controller.flashdelmsg',  :nbmsg => "#{deleted}"
 
     @user.update_unread_message_count!
 

--- a/app/views/messages/index.html.erb
+++ b/app/views/messages/index.html.erb
@@ -58,7 +58,7 @@
     <% end %>
   <% else %>
     <p>
-    <%= t('.donothavemessages', :from => :in ? "" : t('.sentlower') )%>
+    <%= t('.donothavemessages') %>
     </p>
   <% end %>
 

--- a/app/views/stories/_listdetail.html.erb
+++ b/app/views/stories/_listdetail.html.erb
@@ -191,8 +191,7 @@ class="story <%= story.vote && story.vote[:vote] == 1 ? "upvoted" : "" %>
     </div>
   </div>
 </div>
-<div class="mobile_comments <%= story.comments_count == 0 ? "zero" : "" %>"
-style="display: none;">
-  <a href="<%= story.comments_path %>"><%= story.comments_count %></a>
-</div>
+<a href="<%= story.comments_path %>" class="mobile_comments <%= story.comments_count == 0 ? "zero" : "" %>" style="display: none;">
+  <span><%= story.comments_count %></span>
+</a>
 </li>

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -346,14 +346,14 @@ it:
       viewreceived: "Vedi messaggi ricevuti"
       viewsent: "Vedi messaggi inviati"
       subjectlabel: "Oggetto"
-      privatemessages: "Messaggi privati ricevuti"
+      privatemessages: "Messaggi privati"
       sent: "Inviato"
       messages_sent: "inviati"
       from: "Da"
       tomsg: "a"
       received: "Ricevuto"
       deleteselected: "Cancella i messaggi selezionati"
-      donothavemessages: "Non hai messaggi privati da %{from}."
+      donothavemessages: "Non hai alcun messaggio privato."
       sentlower: "invia"
       composemessage: "Scrivi un messaggio"
       tomsglabel: "A:"
@@ -674,7 +674,7 @@ it:
     messages_controller:
       messagestitle: "Messaggi"
       messagessenttitle: "Messaggi inviati"
-      flashdelmsg: "%{nbmsg} message%{plural} supprimé%{plural}."
+      flashdelmsg: "%{nbmsg} messaggio/i eliminato/i."
       pluralmsg: "s"
       flashcannotfindmsg: "Messaggio non trovato."
       flashmsgsentto: "Il messaggio è stato inviato a %{user}."
@@ -795,12 +795,12 @@ it:
         other: quasi %{count} anni
       half_a_minute: mezzo minuto
       less_than_x_minutes:
-        zero: meno di un minuto
-        one: meno di un minuto
+        zero: meno di un minuto fa
+        one: meno di un minuto fa
         other: meno di %{count} minuti
       less_than_x_seconds:
-        zero: meno di un secondo
-        one: meno di un secondo
+        zero: meno di un secondo fa
+        one: meno di un secondo fa
         other: meno di %{count} secondi
       over_x_years:
         one: più di un anno


### PR DESCRIPTION
* Risolve problema trasparenza del menu di downvote quando la storia/commento in questione è trasparente
* Ora il box commenti (nella versione mobile) è completamente cliccabile
* Traduzione della scritta di conferma eliminazione dei messaggi
* “Messaggi privati inviati ricevuti” cambiato in “Messaggi privati inviati”
* Fix scritta quando non c’è nessun messaggio privato inviato o ricevuto
* “Meno di un minuto” cambiata in “Meno di un minuto fa” e “Meno di un secondo” cambiata in “Meno di un secondo fa”